### PR TITLE
fix splitting

### DIFF
--- a/slob.py
+++ b/slob.py
@@ -2023,7 +2023,7 @@ def _cli_convert(args):
                     keys.append((ref.key, ref.fragment))
                 if w is None:
                     volume_count += 1
-                    if split:
+                    if split > 0:
                         current_output = os.path.join(
                             output_dir,
                             ''.join((output_base_noext,

--- a/slob.py
+++ b/slob.py
@@ -2034,7 +2034,7 @@ def _cli_convert(args):
                 current_size = (size_header_and_tags +
                                 w.size_content_types() +
                                 w.size_data())
-                if split and current_size + min_bin_size >= split:
+                if split > 0 and current_size + min_bin_size >= split:
                     t1, w, size_header_and_tags = fin(t1, w, current_output)
         if w:
             fin(t1, w, current_output)


### PR DESCRIPTION
I've just tried to convert enwiki to use a 128MB bin size (which seems more reasonable than the tiny default 384k), and after waiting about 8 hours for the "Mapping blob to keys" step I noticed the script started creating tens of thousands of small, few-kB .slob files. This defeated the purpose of having a larger bin size.

I believe this PR might fix the issue. I didn't pass any -s argument as I wanted one large output file, however it seems that by default the variable `split` gets initialized to -1 (in line 1968). So if I'm thinking correctly, the line 2037 is meant to test whether the user wanted to split the file. Since `split == -1` by default, it will pretty much always match and will always split the output (-1 looks to be a true value for python).