### PR TITLE
Distutils doesn't support entry points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='Slob',
       version='1.0',


### PR DESCRIPTION
Recently I had been trying to package **slob** and **[xdxf2slob](https://github.com/itkach/xdxf2slob)** for Archlinux's [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository), but there is strange thing with `setup.py` script. It contains *entry_points* with *console_scripts* declaration (which is absolutely good), but distutils don't support that and corresponding "binary" in `/usr/bin` won't be created.

Please use setuptools. Even python 2 for windows ships with it now.