### PR TITLE
fix flaky test caused by random iteration over set in _resolve_aliases

### DIFF
--- a/slob.py
+++ b/slob.py
@@ -1083,13 +1083,13 @@ class Writer(object):
             for item in resolved_aliases_reader:
                 ref = pickle.loads(item.content)
                 if previous is not None and ref.key != previous.key:
-                    for bin_index, item_index, fragment in targets:
+                    for bin_index, item_index, fragment in sorted(targets):
                         self._write_ref(previous.key, bin_index, item_index, fragment)
                     targets.clear()
                 targets.add((ref.bin_index, ref.item_index, ref.fragment))
                 previous = ref
 
-            for bin_index, item_index, fragment in targets:
+            for bin_index, item_index, fragment in sorted(targets):
                 self._write_ref(previous.key, bin_index, item_index, fragment)
 
         self._sort()


### PR DESCRIPTION
This test is **sometimes** failing!
Like 1 in 5 to 7 times in average!
```
FAIL: test_alias (slob.TestAlias)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/slob/slob.py", line 1638, in test_alias
    self.assertEqual(item_g1.fragment, "")
AssertionError: 'g-frag1' != ''
- g-frag1
+ 
```

I think it's because iteration order over set is random!
This PR fixes it.