### PR TITLE
Fix Writer.size_data with python 3.14: use f.tell()

### DIFF
--- a/slob.py
+++ b/slob.py
@@ -1218,13 +1218,16 @@ class Writer(object):
         return size
 
     def size_data(self):
+        # Use tell(), not os.stat().st_size: buffered writers (esp. Python 3.14+
+        # DEFAULT_BUFFER_SIZE 128KiB) may not have flushed to the file yet, so stat
+        # understates size
         files = (
             self.f_ref_positions,
             self.f_refs,
             self.f_store_positions,
             self.f_store,
         )
-        return sum((os.stat(f.name).st_size for f in files))
+        return sum(f.tell() for f in files)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
`Writer.size_data` with  was giving incorrect result with python 3.14 and my test was failing (worked with older Python versions)
My use case:
https://github.com/ilius/pyglossary/blob/master/pyglossary/plugins/aard2_slob/writer.py#L263

There are other `os.stat(filename).st_size` calls as well.
I think they all may need to be changed.